### PR TITLE
Closes #6 課題にステータスの概念を持たせる

### DIFF
--- a/app/controllers/task_managements_controller.rb
+++ b/app/controllers/task_managements_controller.rb
@@ -35,6 +35,6 @@ class TaskManagementsController < ApplicationController
 
   private
   def task_management_params
-    params.require(:task_management).permit(:title, :deadline, :memo)
+    params.require(:task_management).permit(:title, :deadline, :memo, :status)
   end
 end

--- a/app/models/task_management.rb
+++ b/app/models/task_management.rb
@@ -2,4 +2,6 @@ class TaskManagement < ApplicationRecord
   validates :title, presence: true
   validates :deadline, presence: true
   validates :title, length: { maximum: 20 }
+
+  enum status:{ "未着手": 0, "着手": 1, "完了": 2 }
 end

--- a/app/views/task_managements/index.html.slim
+++ b/app/views/task_managements/index.html.slim
@@ -7,9 +7,11 @@ table
     tr
       th タイトル
       th 期日
+      th ステータス
 
   tbody
     - @task_managements.each do |task|
       tr
         td = link_to task.title, task_management_path(task)
         td = task.deadline
+        td = task.status

--- a/app/views/task_managements/show.html.slim
+++ b/app/views/task_managements/show.html.slim
@@ -12,4 +12,7 @@ table
     tr
       th メモ
       td = simple_format(@task_management.memo)
+    tr
+      th ステータス
+      td = @task_management.status
 = link_to "編集", edit_task_management_path

--- a/db/migrate/20191029055753_add_status_to_task_managements.rb
+++ b/db/migrate/20191029055753_add_status_to_task_managements.rb
@@ -1,0 +1,5 @@
+class AddStatusToTaskManagements < ActiveRecord::Migration[6.0]
+  def change
+    add_column :task_managements, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_28_064533) do
+ActiveRecord::Schema.define(version: 2019_10_29_055753) do
 
   create_table "task_managements", force: :cascade do |t|
     t.string "title"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 2019_10_28_064533) do
     t.text "memo"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0
   end
 
 end


### PR DESCRIPTION
・課題にステータスの概念を持たせる
・statusカラム(integer)を追加する
・statusはenumを使用する
・ステータスは未着手、着手、完了の3つ
・* 初期状態は未着手にする、default valueを未着手にする
・一覧画面にステータスを表示する
・詳細画面にステータスを表示する

![スクリーンショット 2019-10-29 16 02 29](https://user-images.githubusercontent.com/52396306/67744792-d1cc9f80-fa65-11e9-85f8-c7024e503722.png)

![スクリーンショット 2019-10-29 16 02 40](https://user-images.githubusercontent.com/52396306/67744802-da24da80-fa65-11e9-931e-e73cb7640b40.png)

<img width="410" alt="スクリーンショット 2019-10-29 16 05 37" src="https://user-images.githubusercontent.com/52396306/67744877-15270e00-fa66-11e9-860f-a7528f23bfdd.png">

<img width="545" alt="スクリーンショット 2019-10-29 16 06 23" src="https://user-images.githubusercontent.com/52396306/67744893-18ba9500-fa66-11e9-9237-e035148fcb0a.png">
