### PR TITLE
Closes #7 課題のステータスが変更できること

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'slim-rails'
+
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,8 @@ GEM
     childprocess (3.0.0)
     concurrent-ruby (1.1.5)
     crass (1.0.5)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     ffi (1.11.1)
     globalid (0.4.2)
@@ -214,6 +216,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  enum_help
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.11)

--- a/app/models/task_management.rb
+++ b/app/models/task_management.rb
@@ -6,8 +6,8 @@ class TaskManagement < ApplicationRecord
   validate :check_status
 
   def check_status
-    if status == "wip"
-      if TaskManagement.where(status: "wip").count >= 1
+    if status == "wip" && TaskManagement.where(status: "wip").count >= 1
+      unless status == "wip"
         errors.add(:status, "は着手中です")
       end
     end

--- a/app/models/task_management.rb
+++ b/app/models/task_management.rb
@@ -6,10 +6,8 @@ class TaskManagement < ApplicationRecord
   validate :check_status
 
   def check_status
-    if status == "wip" && TaskManagement.where(status: "wip").count >= 1
-      unless status == "wip"
+    if status == "wip" && TaskManagement.where.not(id: id).where(status: "wip").count >= 1
         errors.add(:status, "は着手中です")
-      end
     end
   end
 end

--- a/app/models/task_management.rb
+++ b/app/models/task_management.rb
@@ -2,6 +2,14 @@ class TaskManagement < ApplicationRecord
   validates :title, presence: true
   validates :deadline, presence: true
   validates :title, length: { maximum: 20 }
+  enum status:{ backlog: 0, wip: 1, closed: 2 }
+  validate :check_status
 
-  enum status:{ "未着手": 0, "着手": 1, "完了": 2 }
+  def check_status
+    if status == "wip"
+      if TaskManagement.where(status: "wip").count >= 1
+        errors.add(:status, "は着手中です")
+      end
+    end
+  end
 end

--- a/app/views/task_managements/_form.html.slim
+++ b/app/views/task_managements/_form.html.slim
@@ -1,16 +1,13 @@
-= form_for @task_management do |f|
-  - if @task_management.errors.any?
-    ul
-      - @task_management.errors.full_messages.each do |message|
-        li = message
+- if @task_management.errors.any?
+  ul
+    - @task_management.errors.full_messages.each do |message|
+      li = message
 
-  = f.submit submit
-  p
-  = f.label :title, "タイトル"
-  = f.text_field :title
-  p
-  = f.label :deadline, "期日"
-  = f.text_field :deadline
-  p
-  = f.label :memo, "メモ"
-  = f.text_area :memo
+= f.label :title, "タイトル"
+= f.text_field :title
+p
+= f.label :deadline, "期日"
+= f.text_field :deadline
+p
+= f.label :memo, "メモ"
+= f.text_area :memo

--- a/app/views/task_managements/edit.html.slim
+++ b/app/views/task_managements/edit.html.slim
@@ -1,3 +1,9 @@
 h2　課題編集
-
-= render partial: "form", locals: { submit: "更新" }
+= form_for @task_management do |f|
+  = f.submit "更新"
+  p
+  = render partial: "form", locals: { f: f }
+  - if request.path_info == edit_task_management_path
+    p
+    = f.label :status, "ステータス"
+    = f.select :status, TaskManagement.statuses_i18n.invert

--- a/app/views/task_managements/index.html.slim
+++ b/app/views/task_managements/index.html.slim
@@ -14,4 +14,4 @@ table
       tr
         td = link_to task.title, task_management_path(task)
         td = task.deadline
-        td = task.status
+        td = task.status_i18n

--- a/app/views/task_managements/new.html.slim
+++ b/app/views/task_managements/new.html.slim
@@ -1,3 +1,5 @@
 h2 課題登録
-
-= render partial: "form", locals: { submit: "登録" }
+= form_for @task_management do |f|
+  = f.submit "登録"
+  p
+  = render partial: "form", locals: { f: f }

--- a/app/views/task_managements/show.html.slim
+++ b/app/views/task_managements/show.html.slim
@@ -14,5 +14,5 @@ table
       td = simple_format(@task_management.memo)
     tr
       th ステータス
-      td = @task_management.status
+      td = @task_management.status_i18n
 = link_to "編集", edit_task_management_path

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,15 @@
+ja:
+  activerecord:
+    models:
+    attributes:
+      task_management:
+        title: タイトル
+        deadline: 期日
+        status: ステータス
+
+  enums:
+    task_management:
+      status:
+        backlog: 未着手
+        wip: 着手中
+        closed: 完了


### PR DESCRIPTION
【課題内容】
・編集画面で課題のステータスを変更できること
・着手中は1件だけのバリデーションをかけること
（・enumの変更）
![スクリーンショット 2019-10-30 15 54 04](https://user-images.githubusercontent.com/52396306/67836474-0e64cd80-fb30-11e9-8e48-90aaa0a4c5cd.png)

![スクリーンショット 2019-10-30 15 54 29](https://user-images.githubusercontent.com/52396306/67836490-16bd0880-fb30-11e9-8ab1-1d4911442b39.png)

![スクリーンショット 2019-10-30 16 36 38](https://user-images.githubusercontent.com/52396306/67837979-aa440880-fb33-11e9-80d2-aaf086e1728e.png)
